### PR TITLE
PoeAgg-12: Added User-Agent to ws and http reqs

### DIFF
--- a/app/js/aggmain.js
+++ b/app/js/aggmain.js
@@ -103,7 +103,8 @@ function callAjax(url, callback, searchInfo)
         	callback(xmlhttp.responseText, searchInfo);
         }		
     }
-    xmlhttp.open("GET", url, true);
+	xmlhttp.open("GET", url, true);
+	xmlhttp.setRequestHeader('User-Agent', "PoeAggregator Version: " + require('electron').remote.app.getVersion())
     xmlhttp.send();
 }
 

--- a/app/js/itemFetcher.js
+++ b/app/js/itemFetcher.js
@@ -103,7 +103,8 @@ function ItemFetcher()
 				playSound(searchInfo.soundId, searchInfo.soundVolume);
 			}		
 	    }
-	    xmlhttp.open("GET", url, true);
+		xmlhttp.open("GET", url, true);
+		xmlhttp.setRequestHeader('User-Agent', "PoeAggregator Version: " + require('electron').remote.app.getVersion())
 		xmlhttp.send();
 	}
 }

--- a/app/js/webSocketWrapper.js
+++ b/app/js/webSocketWrapper.js
@@ -80,7 +80,8 @@ function WebSocketWrapper(url, searchInfo, connectionManager)
 			    	'origin' : 'https://www.pathofexile.com/',
 			        'headers': 
 			        {
-			            'Cookie': cookie.serialize('POESESSID', poesessionid)
+						'Cookie': cookie.serialize('POESESSID', poesessionid),
+						'User-Agent': "PoeAggregator Version: " + require('electron').remote.app.getVersion()
 			        }
 			    }
 			);

--- a/app/package-lock.json
+++ b/app/package-lock.json
@@ -982,7 +982,7 @@
       "integrity": "sha512-l+3HXD0GEI3huGq1njuqtzYK8OYJyXMkOLtQ53pjWh89tvWS2h6l+1zMkYWqlb57+SiQodKZyvMEFb2X+KrFhQ==",
       "dev": true,
       "requires": {
-        "minimist": "^1.2.5"
+        "minimist": "^1.2.0"
       },
       "dependencies": {
         "minimist": {
@@ -1117,7 +1117,7 @@
       "integrity": "sha1-MAV0OOrGz3+MR2fzhkjWaX11yQM=",
       "dev": true,
       "requires": {
-        "minimist": "^1.2.5"
+        "minimist": "0.0.8"
       }
     },
     "ms": {

--- a/app/package.json
+++ b/app/package.json
@@ -1,6 +1,6 @@
 {
   "name": "PoeAggregator",
-  "version": "2.1.5",
+  "version": "2.1.6",
   "description": "testapp",
   "main": "main.js",
   "scripts": {


### PR DESCRIPTION
GGG changed their header requirements for opening websockets.  Requests must now contain a User-Agent header.  In a similar tool a GGG representative mentioned that it is helpful for them to also have a version included in the user agent.  

https://github.com/5k-mirrors/poe-live-search-manager/issues/135

I updated the websocket request to include a header, as well as the http requests for the item fetcher and the normal search request to include a user-agent header.  The header should read the app version from the underlying node process.

Hope this helps and I'm definitely going to look at this tool quite a bit more to see what else can be added/improved!