### PR TITLE
Prevent error on closing from Alt-F4

### DIFF
--- a/app/main.js
+++ b/app/main.js
@@ -406,6 +406,10 @@ async function configurePosition() {
 	}
 
 	mainWindow.on('close', () => {
+		if (mainWindow.isDestroyed()) {
+			return;
+		}
+
 		for (const [windowName, overlay] of overlays.entries())
 		{
 			var bounds = overlay.getBounds();


### PR DESCRIPTION
When the user closes the application without clicking the "X" button, code that runs on close fails because mainWindow has already been destroyed. This code adds a check for that.